### PR TITLE
use-web-yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,10 @@
         "dotenv": "^16.4.6",
         "fs-extra": "^11.2.0",
         "inquirer": "^12.1.0",
+        "js-yaml": "^4.1.0",
         "nodemon": "^3.1.7",
         "simple-git": "^3.27.0",
-        "write-yaml": "^1.0.0",
-        "ws": "^8.18.0",
-        "yaml": "^2.7.0"
+        "ws": "^8.18.0"
       },
       "bin": {
         "uproll": "dist/index.js"
@@ -484,13 +483,10 @@
       "dev": true
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -690,31 +686,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -769,15 +740,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/fs-extra": {
@@ -877,15 +839,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -922,13 +875,12 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -979,27 +931,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/ms": {
@@ -1157,12 +1088,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -1365,33 +1290,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/write": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.3.3.tgz",
-      "integrity": "sha512-e63bsTAFxFUU8OGClhjhhf2R72Njpq6DDTOFFBxDkfZFwoRRKZUx9rll6g/TvY0UcCdKE2OroYZje0v9ROzmfA==",
-      "license": "MIT",
-      "dependencies": {
-        "fs-exists-sync": "^0.1.0",
-        "mkdirp": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/write-yaml": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/write-yaml/-/write-yaml-1.0.0.tgz",
-      "integrity": "sha512-QFB0QwNlUTSsICNb1HV+822MvFpTC1gtKcOfm0B9oqz4qOQXbRuMSxWPWryTEFBEZDWbI5zXabXArvShXTdLiA==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "js-yaml": "^3.8.3",
-        "write": "^0.3.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -1410,18 +1308,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -33,11 +33,10 @@
     "dotenv": "^16.4.6",
     "fs-extra": "^11.2.0",
     "inquirer": "^12.1.0",
+    "js-yaml": "^4.1.0",
     "nodemon": "^3.1.7",
     "simple-git": "^3.27.0",
-    "write-yaml": "^1.0.0",
-    "ws": "^8.18.0",
-    "yaml": "^2.7.0"
+    "ws": "^8.18.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { LogsCmdAPICLI } from './services/logs-cmd-cli';
 import { mainCMDCLI } from './services/main.cmd-cli';
 import { apiDeployCmdCli } from './services/api-deploy-cmd-cli';
 import packageJson from '../package.json';
+import { RollupDeployEndpoint } from './services/rollup-deploy-endpoint';
 
 startLog();
 const program = new Command();
@@ -16,7 +17,7 @@ program
   .description('A CLI tool for manage opstack deployment')
   .version(packageJson.version);
 
-program.command('run').description('Run Opstack CLI Tool').action(mainCMDCLI);
+program.command('run [endpoint]').description('Run Opstack CLI Tool').action((endpoint) => mainCMDCLI(endpoint));
 program
   .command('api')
   .description('Run Opstack CLI API')

--- a/src/services/get-project-details.ts
+++ b/src/services/get-project-details.ts
@@ -1,24 +1,45 @@
 import inquirer from 'inquirer';
 import { runCommand } from '../utils';
+
+
+export async function getProjectName(){
+  const projectName = await inquirer.prompt(
+    [
+      {
+        type: 'input',
+        name: 'projectName',
+        message: 'Enter the project name',
+        default: 'myRollup',
+      },
+    ],
+  )
+  return projectName;
+}
+
+
+export async function getNetworkType(){
+  const networkType = await inquirer.prompt(
+    [
+      {
+        type: 'list',
+        name: 'networkType',
+        message: 'Are you planning on making a devnet or testnet?',
+        choices: ['devnet', 'testnet'],
+        default:
+          'devnet',
+      }
+    ],
+  )
+  return networkType;
+}
+
 export async function getProjectDetails(){
     // Get the name of the project, the config file and type of rollup
-     const projectDetails = await inquirer.prompt(
-        [
-          {
-            type: 'input',
-            name: 'projectName',
-            message: 'Enter the project name',
-            default: 'myRollup',
-          },
-          {
-            type: 'list',
-            name: 'networkType',
-            message: 'Are you planning on making a devnet or testnet?',
-            choices: ['devnet', 'testnet'],
-            default:
-              'devnet',
-          }
-        ],
-      )
+    const projectName = await getProjectName();
+    const networkType = await getNetworkType();
+    const projectDetails = {
+      projectName: projectName.projectName,
+      networkType: networkType.networkType
+    }
       return projectDetails;
 }

--- a/src/services/main.cmd-cli.ts
+++ b/src/services/main.cmd-cli.ts
@@ -6,7 +6,7 @@ import { LogsCmd } from './logs-cmd-cli';
 import { StatusCMDCLI } from './status-cmd-cli';
 import { StartCMDCLI } from './start-cmd-cli';
 import { StopCMDCLI } from './stop-cmd-cli';
-
+import { RollupDeployEndpoint } from './rollup-deploy-endpoint';
 enum Action {
   deployUI = 'deployUI',
   deploy = 'deploy',
@@ -22,8 +22,14 @@ enum Action {
   exit = 'exit',
 }
 
-export const mainCMDCLI = async () => {
+export const mainCMDCLI = async (endpoint:string) => {
   await apiDeployCmdCli();
+
+
+  if (endpoint){
+    RollupDeployEndpoint(endpoint);
+    return;
+  }
   // select the command
 
   const actionAns = await inquirer.prompt([

--- a/src/services/rollup-deploy-cmd-cli.ts
+++ b/src/services/rollup-deploy-cmd-cli.ts
@@ -1,5 +1,5 @@
 import inquirer from 'inquirer';
-import { rollupConfigLog , kurtosisRunTestnetLog, deployCompleteLog, deployFailedLog} from '../utils/log';
+import { rollupConfigLog , kurtosisRunConfig, deployCompleteLog, deployFailedLog} from '../utils/log';
 import { runKurtosisCommand , runCommand} from '../utils';
 import { configToYAML } from '../utils/configtoYAML';
 import path from 'path';
@@ -68,7 +68,7 @@ async function deployTestnet(projectDetails: {projectName: string, networkType: 
       return;
     }
 
-    kurtosisRunTestnetLog();
+    kurtosisRunConfig();
 
     // Run Kurtosis using the testnet config
     let command =  runKurtosisCommand(

--- a/src/services/rollup-deploy-endpoint.ts
+++ b/src/services/rollup-deploy-endpoint.ts
@@ -1,0 +1,72 @@
+import inquirer from 'inquirer';
+import { rollupConfigLog , kurtosisRunConfig, deployCompleteLog, deployFailedLog} from '../utils/log';
+import { runKurtosisCommand , runCommand} from '../utils';
+import { configToYAML } from '../utils/configtoYAML';
+import path from 'path';
+import { GetTestnetDetails } from "./get-testnet-details"
+import { getProjectDetails, getProjectName } from './get-project-details';
+import fs from 'fs';
+import { PATH_NAME } from '../utils/config';
+import { assert, error } from 'console';
+const yaml = require('js-yaml');
+
+
+export async function RollupDeployEndpoint(endpoint:string) {
+  try{
+    rollupConfigLog();
+  
+    const projectName = await getProjectName();
+  
+    // make a directory with the project name in a project folder
+    await runCommand('mkdir -p ./dist/projects/');
+    await runCommand('mkdir -p ./dist/projects/' + projectName.projectName + "/");
+    
+    await downloadConfig(endpoint, projectName.projectName);
+    
+    kurtosisRunConfig();
+    await deployFromEndpoint(endpoint, projectName.projectName);
+ 
+  } catch(error){
+    deployFailedLog(String(error));
+  }
+}
+
+async function downloadConfig(endpoint:string, projectName:string) {  
+  try{
+    const response = await fetch(endpoint);
+    if (!response.ok) {
+      throw new Error('Could not download config file');
+    }
+    const text = await response.text();
+    const yamltext = yaml.load(text);
+    const yamlObj = yaml.dump(yamltext);
+    // write yaml object to file
+    fs.writeFile(`${PATH_NAME.UPROLL_CLI}/dist/projects/${projectName}/config.yaml`, yamlObj, (error)=>{
+      if (error){
+        throw new Error('Could not write retrieved file to yaml');
+      }
+    });
+  }catch(error){
+    throw error;
+  }
+}
+
+async function deployFromEndpoint(endpoint:string, projectName:string) {
+  let command =  runKurtosisCommand(
+    'kurtosis',
+    [
+      'run',
+      './optimism-package',
+      '--args-file',
+      endpoint,
+      '--enclave',
+      projectName
+    ]
+  );
+  command.then(
+    deployCompleteLog,
+    (err) => deployFailedLog(String(err))
+  );
+
+}
+

--- a/src/utils/configtoYAML.ts
+++ b/src/utils/configtoYAML.ts
@@ -5,7 +5,7 @@ export function configToYAML(projectName:string, postData: {[key: string]: any})
 
 
     const templatePath = path.join(__dirname, '../templates/testnet_config.yaml');
-    const config = yaml.safeLoad(fs.readFileSync(templatePath, 'utf8'));
+    const config = yaml.load(fs.readFileSync(templatePath, 'utf8'));
 
     // setting level 1 config
     config.external_l1_network_params = {
@@ -57,7 +57,7 @@ export function configToYAML(projectName:string, postData: {[key: string]: any})
         config.optimism_package.observability = {"grafana_params": {"dashboard_sources":[]}}
         config.optimism_package.observability.grafana_params.dashboard_sources.push(postData.GRAFANA_DASHBOARD_SOURCE);
     }
-    const newYaml = yaml.safeDump(config);
+    const newYaml = yaml.dump(config);
     const newConfigPath = path.join(__dirname, `../projects/${projectName}/config.yaml`);
     fs.writeFileSync(newConfigPath, newYaml, 'utf8');
     console.log("Config file created successfully");

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -137,7 +137,7 @@ export const rollupConfigLog = () => {
   );
 };
 
-export const kurtosisRunTestnetLog = () =>{
+export const kurtosisRunConfig = () =>{
   console.log(
 
     colors.fg.blue,


### PR DESCRIPTION
PR adds so that a user can run `uproll run {config_endpoint}` and it will:

- Make a request to the address
- Extract the body text
- Save as a yaml in a project folder
- Do `kurtosis run ./optimism-package --args-file{config.yaml}`, passing in this local version of the yaml